### PR TITLE
Revert "Use default GITHUB_TOKEN for voting workflows (#37)"

### DIFF
--- a/.github/workflows/close-voting.yml
+++ b/.github/workflows/close-voting.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Count votes and update discussion
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.DISCUSSION_TOKEN }}
           script: |
             // Find the active voting discussion by searching for the marker
             const searchQuery = `

--- a/.github/workflows/start-voting.yml
+++ b/.github/workflows/start-voting.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Create voting discussion with topic comments
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.DISCUSSION_TOKEN }}
           script: |
             const category = '${{ inputs.discussion_category }}';
             


### PR DESCRIPTION
This reverts commit ff0334db520dbac792b56296e5ff6d14c00f3ef5.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /kind bug
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Reverts:
* https://github.com/gardener/hackathon/pull/37

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:
